### PR TITLE
Add proper threaded mode

### DIFF
--- a/build_rpi4_arm64.sh
+++ b/build_rpi4_arm64.sh
@@ -11,4 +11,5 @@ fi
 cp "NDI SDK for Linux"/include/* include/
 cp "NDI SDK for Linux"/lib/aarch64-rpi4-linux-gnueabi/* lib/
 
-g++ -std=c++11 -pthread  -Wl,--allow-shlib-undefined -Wl,--as-needed -Iinclude/ -L lib -o build/v4l2ndi main.cpp PixelFormatConverter.cpp -lndi -ldl
+g++ -std=c++14 -pthread  -Wl,--allow-shlib-undefined -Wl,--as-needed -Iinclude/ -L lib -o build/v4l2ndi main.cpp PixelFormatConverter.cpp -lndi -ldl -g -O2
+

--- a/build_rpi4_armhf.sh
+++ b/build_rpi4_armhf.sh
@@ -11,4 +11,5 @@ fi
 cp "NDI SDK for Linux"/include/* include/
 cp "NDI SDK for Linux"/lib/arm-rpi4-linux-gnueabihf/* lib/
 
-g++ -std=c++11 -pthread  -Wl,--allow-shlib-undefined -Wl,--as-needed -Iinclude/ -L lib -o build/v4l2ndi main.cpp PixelFormatConverter.cpp -lndi -ldl
+g++ -std=c++14 -pthread  -Wl,--allow-shlib-undefined -Wl,--as-needed -Iinclude/ -L lib -o build/v4l2ndi main.cpp PixelFormatConverter.cpp -lndi -ldl
+

--- a/build_x86_64.sh
+++ b/build_x86_64.sh
@@ -11,4 +11,5 @@ fi
 cp "NDI SDK for Linux"/include/* include/
 cp "NDI SDK for Linux"/lib/x86_64-linux-gnu/* lib/
 
-g++ -std=c++11 -pthread  -Wl,--allow-shlib-undefined -Wl,--as-needed -Iinclude/ -L lib -o build/v4l2ndi main.cpp PixelFormatConverter.cpp -lndi -ldl
+g++ -std=c++14 -pthread  -Wl,--allow-shlib-undefined -Wl,--as-needed -Iinclude/ -L lib -o build/v4l2ndi main.cpp PixelFormatConverter.cpp -lndi -ldl
+


### PR DESCRIPTION
Migrate YUY2 conversion and sending to NDI stack to a separate thread
when called with --threaded.  Requires using c++14 (for make_unique).

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>