### PR TITLE
Setting FPS for V4L2 device to match connection rate

### DIFF
--- a/download_NDI_SDK.sh
+++ b/download_NDI_SDK.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
 #download and extract NDI
-curl -s https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v5_Linux.tar.gz | tar xvz -C /tmp/
-yes y | bash /tmp/Install_NDI_SDK_v5_Linux.sh > /dev/null
+curl -s https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v6_Linux.tar.gz | tar xvz -C /tmp/
+yes y | bash /tmp/Install_NDI_SDK_v6_Linux.sh > /dev/null

--- a/main.cpp
+++ b/main.cpp
@@ -75,6 +75,8 @@ int                     image_threaded = 0;
 int                     last_read_frame = 0;
 int                     num_v4l2_buffers = 4; 
 
+static bool		print_drops = 0;
+
 struct timeval start, end;
 
 unsigned int frames = 0;
@@ -330,7 +332,11 @@ static void queue_push(std::unique_ptr<v4l2_buffer> buf){
 
     m_queue.pop();
     // LOG(LOG_ERR, "!");	// Dropped an item from the queue!
-    printf("!"); fflush(stdout);
+    if (print_drops) {
+	// Drops are legitimate if, for example, sending a device that produces data at 60fps
+	// onto a 30fps NDI connection
+    	printf("!"); fflush(stdout);
+    }
   }
 
   // Unlock the queue...
@@ -368,7 +374,7 @@ static void process_image_thread(void){
   std::unique_ptr<NDIlib_video_frame_v2_t> frame, last_frame;
 
   // Cycle until we are told to exit
-  while (true)
+  while (!exit_thread)
   {
     // Wait for the queue to have some data
     queue_wait();

--- a/main.cpp
+++ b/main.cpp
@@ -662,6 +662,7 @@ long_options[] = {
         { "video", required_argument,  NULL, 'v' },
         { "queue", required_argument,  NULL, 'q' },
         { "fix", no_argument,       NULL, 'c' },
+	{ "print_drops", no_argument, NULL, 'D' },
         { 0, 0, 0, 0 }
 };
 
@@ -714,7 +715,10 @@ int main(int argc, char **argv){
      break;   
     case 'c': //set HDMI to CSI fix - applies a memcpy to the frame before going to the NDI stack. Not sure why this fixes the issue
      fix_csi = 1;
-     break;            
+     break;
+    case 'D':
+     print_drops = true;
+     break;
     default:
      usage(stderr, argc, argv);
      exit(EXIT_FAILURE);


### PR DESCRIPTION
I have been using this package with a USB HDMI capture device that, by default, captures at 60 FPS, transmitting on a 30fps NDI connection. In threaded mode I was seeing lots of "drop" indications and flickering output at the NDI receiver. 
This code change uses the V4L2_S_PARM call to set the device FPS rate to match the connection rate . This removes the flicker and most of the drops.
I also changed the non-threaded mode to use the more efficient in-place YUYV->UYUV conversion.
